### PR TITLE
proj links for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,5 @@ authors = [{name = "Tariq Shihadah", email = "tariq.shihadah@gmail.com"}]
 dependencies = ["numpy", "matplotlib", "shapely>=1.7", "pandas>=1.1", "geopandas>=0.10.2", "rangel>=0.0.7"]
 
 [project.urls]
-documentation = "https://readthedocs.org"
-repository = "https://github.com"
+documentation = "https://linref.readthedocs.io/"
+repository = "https://github.com/tariqshihadah/linref"


### PR DESCRIPTION
haven't look at packaging or putting stuff on pypi before so was curious and noticed these links on pypi are just to the general rtd and github pages. Will updating these update the links in pypi?

![image](https://github.com/tariqshihadah/linref/assets/38143549/4a9f6aa9-f1aa-4dbc-a0b0-06090d09550c)