### PR TITLE
Maintain `to_windows` dtype during numpy concatenation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ cython_debug/
 
 # Other
 NOTES
+DEBUG/
+TEST*.ipynb

--- a/linref/events/collection.py
+++ b/linref/events/collection.py
@@ -1242,24 +1242,17 @@ class EventsFrame(object):
                         rng.rng.T,               # Window bounds
                         [[index]]*rng.num_ranges # Parent index value
                     ],
-                    axis=1
+                    axis=1, dtype=object
                 )
             )
 
         # Merge and prepare data, return
-        windows = np.concatenate(windows, axis=0)
+        windows = np.concatenate(windows, axis=0, dtype=object)
         df = pd.DataFrame(
             data=windows,
             columns=self.keys + [self.beg, self.end, 'index_parent'],
             index=None,
         )
-        # Enforce data types
-        dtypes = {
-            **events.dtypes,
-            'index_parent': events.index.dtype
-        }
-        dtypes = {col: dtypes[col] for col in df.columns}
-        df = df.astype(dtypes, copy=False)
         # Retain original fields if requested
         if retain:
             df = df.merge(

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ rangel>=0.0.7
 scipy>=1.4.1
 build
 twine
+ipython


### PR DESCRIPTION
During the construction of new windows, repeats of the `keys` values along with the new event boundaries are concatenated with `numpy`. This caused loss of dtype in the past as data was commonly converted to a `str`-like type. Now enforcing an `object` dtype on concatenations which retains dtypes. Easy fix and also allowed for the removal of a band-aid dtype re-casting after the concatenation.

Thanks @phildias for finding this!