### PR TITLE
explicitly retain dtypes in to_windows

### DIFF
--- a/linref/events/collection.py
+++ b/linref/events/collection.py
@@ -1248,17 +1248,21 @@ class EventsFrame(object):
 
         # Merge and prepare data, return
         windows = np.concatenate(windows, axis=0, dtype=object)
+        columns = self.keys + [self.beg, self.end, 'index_parent']
+        dtypes = {col: type(sample) for col, sample in zip(columns, windows[0])}
         df = pd.DataFrame(
             data=windows,
             columns=self.keys + [self.beg, self.end, 'index_parent'],
             index=None,
-        )
+        ).astype(dtypes, copy=False)
+
         # Retain original fields if requested
         if retain:
             df = df.merge(
                 self.df[self.others], left_on='index_parent', 
                 right_index=True, how='left'
             )
+            
         # Prepare collection and return
         res = self.__class__(
             df,

--- a/linref/events/collection.py
+++ b/linref/events/collection.py
@@ -1249,12 +1249,17 @@ class EventsFrame(object):
         # Merge and prepare data, return
         windows = np.concatenate(windows, axis=0, dtype=object)
         columns = self.keys + [self.beg, self.end, 'index_parent']
-        dtypes = {col: type(sample) for col, sample in zip(columns, windows[0])}
         df = pd.DataFrame(
             data=windows,
-            columns=self.keys + [self.beg, self.end, 'index_parent'],
+            columns=columns,
             index=None,
-        ).astype(dtypes, copy=False)
+        )
+        # Enforce dtypes
+        dtypes = {col: events.dtypes[col] for col in self.keys}
+        dtypes[self.beg] = float
+        dtypes[self.end] = float
+        dtypes['index_parent'] = events.index.dtype
+        df = df.astype(dtypes, copy=False, errors='ignore')
 
         # Retain original fields if requested
         if retain:


### PR DESCRIPTION
@phildias Turns out my fix of the `to_windows` bug that you brought up last week accidentally created a second bug, whoops! Basically, I was retaining the dtypes of window keys and events bounds by using the `object` dtype during numpy concatenation. Well, the issue with that is that pandas decided not to infer from the inner dtypes and wound up giving all fields a dtype of `object`, meaning that operations downstream of the `to_windows` call don't operate correctly. Hopefully you didn't get the chance to find that out on your own.

At any rate, feel free to take a look but hold off on merging. Shouldn't need direct testing on your end since a colleague and I will be testing it further in application and we'll take care of the merge.