### PR TITLE
use dynamic index naming when interpreting sjoin

### DIFF
--- a/linref/events/synthesis.py
+++ b/linref/events/synthesis.py
@@ -186,10 +186,12 @@ def generate_linear_events(
         
         # Intersect boundary geometries
         intersection = gpd.sjoin(ends, begs)
-        intersection['index_left'] = intersection.index
         # Get all unique matches between the line end points and other line 
         # begin points
-        pairs = intersection[['index_left','index_right']].values
+        index_left = f'{df.index.name}_left' if df.index.name else 'index' # Current behavior only applies suffix if index name is not present
+        index_right = f'{df.index.name}_right' if df.index.name else 'index_right'
+        pairs = intersection.reset_index(drop=False) \
+            [[index_left, index_right]].values
         
         # Remove instances of multiple matches on left or right; only the 
         # first unique value on the left and right are kept based on original 


### PR DESCRIPTION
Per #29, fixing the `lr.generate_linear_events` function's misbehavior when the analyzed geodataframe has an explicitly named index. Tested with code below. `gdf.set_index...` can be removed to test baseline case as well. Initial testing looks good.

```
import pandas as pd
import geopandas as gpd
import linref as lr
from shapely import LineString

# Create dummy data
gdf = gpd.GeoDataFrame({
    'id': [101, 102, 103],
    'geometry': [LineString([(0, 0), (1, 0)]), LineString([(1, 0), (1, 1)]), LineString([(1, 1), (2, 1)])]
})
gdf.set_index('id', inplace=True)

# Generate linear events
lr.generate_linear_events(gdf)
```