### PR TITLE
added dissolve command in cut example

### DIFF
--- a/examples/creating_line_geoms_from_mm.ipynb
+++ b/examples/creating_line_geoms_from_mm.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "id": "7c4eb0d7-a00c-44fb-9b89-73652a1d6327",
    "metadata": {},
    "outputs": [],
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "id": "2067add6-53de-4d7f-aab9-846a50b44926",
    "metadata": {},
    "outputs": [],
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "id": "4151acae-13b6-41ce-9d00-029766c45276",
    "metadata": {},
    "outputs": [],
@@ -79,12 +79,16 @@
     "# For the reference object, notice how we specify the `beg` and `end` parameters because we are dealing with a link-based object.\n",
     "# The idea here is that the `beg` and `end` columns indicate which columns contain the start and end mile marker information for \n",
     "# each link. \n",
-    "ref_ec = lr.EventsCollection(\n",
-    "    ref_gdf,\n",
-    "    keys=['route_id'],\n",
-    "    beg='beg',\n",
-    "    end='end',\n",
-    "    geom='geometry'\n",
+    "# The `EventsCollection` of the reference object also needs to be dissolved to allow the user to generate geometries that span \n",
+    "# more than just one link in the reference network. \n",
+    "ref_ec = (lr\n",
+    "          .EventsCollection(ref_gdf,\n",
+    "                            keys=['route_id'],\n",
+    "                            beg='beg',\n",
+    "                            end='end',\n",
+    "                            geom='geometry')\n",
+    "          .dissolve(agg_geometry=True, \n",
+    "                    agg_routes=True)\n",
     ")\n",
     "\n",
     "# For the line object, we also need to specify the `beg` and `end` parameters. \n",
@@ -107,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "id": "3cd299b7-e762-4d5d-a9f1-a095fb0e790b",
    "metadata": {},
    "outputs": [],
@@ -126,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "id": "b709333b-6f87-4df4-8dee-82661ec4b95e",
    "metadata": {},
    "outputs": [
@@ -134,10 +138,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2    MULTILINESTRING ((2 2, 3 2))\n",
-      "3    MULTILINESTRING ((3 2, 4 2))\n",
       "0    MULTILINESTRING ((1 0, 2 0))\n",
       "1    MULTILINESTRING ((2 0, 3 0))\n",
+      "2    MULTILINESTRING ((2 2, 3 2))\n",
+      "3    MULTILINESTRING ((3 2, 4 2))\n",
       "Name: route, dtype: object\n"
      ]
     }
@@ -163,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "id": "073e2a67-b1db-4eb4-9023-e962523ee911",
    "metadata": {},
    "outputs": [
@@ -171,22 +175,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   line_id route_id  beg  end  \\\n",
-      "0        1        A    1    2   \n",
-      "1        2        A    2    3   \n",
-      "2        3        B    2    3   \n",
-      "3        4        B    3    4   \n",
-      "\n",
-      "                                            geometry  \n",
-      "0  MULTILINESTRING ((1.00000 0.00000, 2.00000 0.0...  \n",
-      "1  MULTILINESTRING ((2.00000 0.00000, 3.00000 0.0...  \n",
-      "2  MULTILINESTRING ((2.00000 2.00000, 3.00000 2.0...  \n",
-      "3  MULTILINESTRING ((3.00000 2.00000, 4.00000 2.0...  \n",
-      "   line_id route_id  beg  end\n",
-      "0        1        A    1    2\n",
-      "1        2        A    2    3\n",
-      "2        3        B    2    3\n",
-      "3        4        B    3    4\n"
+      "   line_id route_id  beg  end                      geometry\n",
+      "0        1        A    1    2  MULTILINESTRING ((1 0, 2 0))\n",
+      "1        2        A    2    3  MULTILINESTRING ((2 0, 3 0))\n",
+      "2        3        B    2    3  MULTILINESTRING ((2 2, 3 2))\n",
+      "3        4        B    3    4  MULTILINESTRING ((3 2, 4 2))\n"
      ]
     }
    ],
@@ -213,7 +206,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Addressing the problem described in Issue #28 . 
There was nothing wrong with the base code itself - I'm just fixing the example that explains how to use the `cut()` function to draw new line geometries. 
With this edit, the example is more complete and will work properly for cases where the input line might possibly span multiple links from the reference network.