### PR TITLE
Support null-group events in relations; clearer sort error

### DIFF
--- a/linref/events/base.py
+++ b/linref/events/base.py
@@ -723,7 +723,15 @@ class EventsData:
             keys.append(arr)
         
         # Apply sorting
-        index = np.lexsort(keys)
+        try:
+            index = np.lexsort(keys)
+        except TypeError as e:
+            raise TypeError(
+                f"Unable to sort events by {by} because the data contains "
+                "a mix of incomparable types (e.g. strings alongside "
+                "NaN/float values). Please ensure that data is complete and "
+                "properly typed."
+            ) from e
         return index
 
     def sort(self, by: str | list[str], ascending: bool | list[bool] = True, return_index: bool = False, inplace: bool = False) -> EventsData | tuple[EventsData, np.ndarray] | None:

--- a/linref/events/relate.py
+++ b/linref/events/relate.py
@@ -1826,6 +1826,20 @@ class EventsRelation(object):
 # Events relation core methods
 # -----------------------------------------------------------------------------
 
+def _valid_group_mask(groups: np.ndarray) -> np.ndarray:
+    """
+    Return a boolean mask of events whose group key is fully non-null. Handles
+    both plain arrays and structured/record arrays (multi-column keys), where
+    an event is invalid if any key field is null.
+    """
+    if groups.dtype.names is not None:
+        mask = np.ones(len(groups), dtype=bool)
+        for name in groups.dtype.names:
+            mask &= ~pd.isnull(groups[name])
+        return mask
+    return ~pd.isnull(groups)
+
+
 def _grouped_operation_wrapper(func) -> callable:
     """
     Decorator for wrapping functions that operate on grouped data.
@@ -1847,6 +1861,34 @@ def _grouped_operation_wrapper(func) -> callable:
             # Return group-less operation
             return func(left, right, *args, **kwargs)
         else:
+            # Exclude events with null group keys: they belong to no group and
+            # so have no intersection/overlap. We compute on the null-free
+            # subset and scatter results back, leaving their rows/columns empty.
+            # Skipped entirely when no nulls are present (common case).
+            left_valid = _valid_group_mask(left.groups)
+            right_valid = _valid_group_mask(right.groups)
+            if not (left_valid.all() and right_valid.all()):
+                # Original positions of valid events, used to scatter results.
+                left_map = np.flatnonzero(left_valid)
+                right_map = np.flatnonzero(right_valid)
+                if left_map.size == 0 or right_map.size == 0:
+                    # One side is entirely null -> no possible relations.
+                    sub = sp.coo_matrix((left_map.size, right_map.size))
+                else:
+                    # Recurse on the null-free subset. On re-entry both sides
+                    # are valid, so this branch is skipped and the normal
+                    # computation below runs in full (one-level recursion).
+                    sub = sp.coo_matrix(wrapper(
+                        left.select(left_valid, inplace=False),
+                        right.select(right_valid, inplace=False),
+                        *args, grouped=True, **kwargs
+                    ))
+                # Remap compacted (row, col) back to original positions.
+                return sp.csr_matrix(
+                    (sub.data, (left_map[sub.row], right_map[sub.col])),
+                    shape=(left.num_events, right.num_events)
+                )
+
             # Sort both datasets and get group boundaries
             # This avoids repeated np.isin calls while keeping memory usage low
             left_sorted = left.reset_index().sort_standard(inplace=False)

--- a/linref/tests/test_events_relate.py
+++ b/linref/tests/test_events_relate.py
@@ -1291,5 +1291,75 @@ class TestSum(unittest.TestCase):
         self.assertAlmostEqual(float(result), 0.0)
 
 
+class TestNullGroupHandling(unittest.TestCase):
+    """Test cases for relations between events with null group keys."""
+
+    def test_overlay_with_null_group(self):
+        """Events with a null group produce an empty row and match dropping."""
+        left = base.EventsData(
+            begs=np.array([0.0, 0.0, 5.0]),
+            ends=np.array([10.0, 10.0, 15.0]),
+            groups=np.array(['A', np.nan, 'A'], dtype=object)
+        )
+        right = base.EventsData(
+            begs=np.array([0.0, 5.0]),
+            ends=np.array([10.0, 15.0]),
+            groups=np.array(['A', 'A'], dtype=object)
+        )
+        result = relate.EventsRelation(left, right).overlay(normalize=False)
+
+        # Output preserves full shape (3 left events x 2 right events)
+        self.assertEqual(result.shape, (3, 2))
+        # The null-group event (row 1) has no overlap with anything
+        np.testing.assert_array_equal(result.toarray()[1], [0.0, 0.0])
+        # Valid rows are unaffected: left[0] (0-10, A) overlaps right[0] (0-10)
+        # fully and right[1] (5-15) by 5 units
+        self.assertAlmostEqual(result[0, 0], 10.0)
+        self.assertAlmostEqual(result[0, 1], 5.0)
+
+    def test_mode_with_null_group(self):
+        """Mode aggregation over string data succeeds despite null groups."""
+        left = base.EventsData(
+            begs=np.array([0.0, 0.0, 0.0, 5.0]),
+            ends=np.array([10.0, 10.0, 10.0, 15.0]),
+            groups=np.array(['A', 'B', np.nan, 'A'], dtype=object)
+        )
+        right = base.EventsData(
+            begs=np.array([0.0, 0.0, 5.0]),
+            ends=np.array([10.0, 10.0, 15.0]),
+            groups=np.array(['A', 'B', 'A'], dtype=object)
+        )
+        relation = relate.EventsRelation(left, right)
+        data = np.array(['x', 'y', 'z'], dtype=object)
+
+        result = relation.mode(data=data, axis=1)
+
+        # The null-group left event (index 2) has no intersections -> None
+        self.assertIsNone(result[2])
+        # Valid events resolve to the expected modes
+        self.assertEqual(result[0], 'x')
+        self.assertEqual(result[1], 'y')
+        self.assertEqual(result[3], 'z')
+
+    def test_null_groups_do_not_match_each_other(self):
+        """Null-group events on both sides must not intersect one another."""
+        left = base.EventsData(
+            begs=np.array([0.0, 0.0]),
+            ends=np.array([10.0, 10.0]),
+            groups=np.array(['A', np.nan], dtype=object)
+        )
+        right = base.EventsData(
+            begs=np.array([0.0, 0.0]),
+            ends=np.array([10.0, 10.0]),
+            groups=np.array(['A', np.nan], dtype=object)
+        )
+        result = relate.EventsRelation(left, right).intersect()
+
+        # The two null-group events (row 1, col 1) must not match
+        self.assertFalse(bool(result.toarray()[1, 1]))
+        # The valid pair (A <-> A) does intersect
+        self.assertTrue(bool(result.toarray()[0, 0]))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
Makes event relations robust to rows with **null group keys**. Previously, relating two datasets where either side had missing key/group values raised a cryptic `TypeError: '<' not supported between instances of 'str' and 'float'` from deep inside `np.lexsort` during grouped overlay/intersect. Now such rows are handled gracefully: an event with no valid group key simply has **no intersection or overlap** with anything, producing empty rows/columns in the relation matrix.

## Motivation
Null group keys are common in real-world LRS data (e.g. a route/key column with missing values). The prior failure surfaced far from its cause — in the aggregation call stack (`.mode()`, `.mean()`, etc.) — with a message that gave no indication that a missing key was the culprit or how to fix it.

## Changes
- **`linref/events/relate.py`**
  - `_grouped_operation_wrapper` now excludes null-group events before the grouped computation, runs the full, unmodified relation on the null-free subset (one-level recursion), then scatters results back to original positions — leaving null rows/columns empty. The common (no-null) path is untouched aside from two O(n) validity checks.
  - Adds `_valid_group_mask`, a null-detection helper robust to both plain arrays and **structured/record arrays** (multi-column keys), where an event is invalid if any key field is null.
- **`linref/events/base.py`**
  - `EventsData.argsort` wraps `np.lexsort` with a clear `TypeError` message as a safety net for any path that bypasses the accessor, explaining the mixed-type/NaN cause.
- **`linref/tests/test_events_relate.py`**
  - Adds `TestNullGroupHandling` with three cases: null-group overlay yields an empty row, mode aggregation succeeds despite null groups, and null-group events on both sides do not match each other.

## Behavior change
Relating datasets with null group keys **no longer raises**. Affected events yield `count = 0`, `overlay/intersect = 0`, and `mean = NaN` / `mode = None`, i.e. "no relationship." Datasets without null groups are unaffected.

## Performance
- No-null case: unchanged except two O(n) `isnull` checks (short-circuits immediately).
- Null case: computes on *fewer* events, then an O(nnz) index remap; output shape and sparsity match processing the valid events directly.

## Testing
Full suite green: **388 passed, 45 subtests passed**. Includes 3 new targeted tests. Verified the original `.mode()` failure scenario now returns expected results.