### PR TITLE
fix(geometry): pin cut terminal M to requested bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 **Bug Fixes:**
 
 * Fixed internal method decorators to preserve wrapped function metadata via `functools.wraps`, so decorated methods now render with proper signatures and docstrings in the API documentation.
+* Fixed `LineStringM.cut()` to pin the terminal M values of the cut geometry to the exact requested begin/end measures instead of re-interpolating them. Re-interpolation could introduce sub-ULP drift between adjacent segments' shared borders during the dissolve → resegment workflow, causing `DataFrame.lr.dissolve()` to incorrectly report contiguous geometries as disjointed. Also removed a now-unreachable M/coordinate length-reconciliation branch, since `substring_m_coords()` always returns equal-length arrays.
 
 ## 1.0.0 (2026-07-10) - Major Architectural Overhaul
 

--- a/linref/geometry/linestring_m.py
+++ b/linref/geometry/linestring_m.py
@@ -572,23 +572,8 @@ class LineStringM:
             warnings.warn('Zero-length geometry created', RuntimeWarning)
             new_geom = LineString([new_geom_coords[0], new_geom_coords[0]])
         
-        # Identify and address cases where number of M values does not match
-        # number of vertices (due to the substring operation producing zero-
-        # length chords)
         if new_geom_m is not None:
-            if len(new_geom_m) < len(new_geom_coords):
-                # Warn for now
-                warnings.warn(
-                    "M values length does not match number of vertices in cut "
-                    "geometry; adjusting to match", RuntimeWarning)
-                chord_lengths = get_chord_lengths(new_geom, normalized=False)
-                if chord_lengths[0] == 0:
-                    new_geom = LineString(new_geom_coords[1:])
-                elif chord_lengths[-1] == 0:
-                    new_geom = LineString(new_geom_coords[:-1])
-                else:
-                    raise ValueError(
-                        f"M values length of {len(new_geom_m)} does not match number "
-                        f"of vertices in cut geometry of {len(new_geom_coords)}."
-                    )
+            # Pin the terminal M values to the exact requested boundary measures.
+            new_geom_m[0] = beg_m
+            new_geom_m[-1] = end_m
         return LineStringM(new_geom, m=new_geom_m)


### PR DESCRIPTION
LineStringM.cut re-interpolated terminal M values, causing sub-ULP drift between adjacent resegmented events at their shared border, making lr.dissolve falsely report contiguous geometries as disjointed. Pin terminal M to the exact requested begin/end measures and drop the now unreachable M/coordinate length-reconciliation branch (substring_m_coords returns equal-length arrays; the LineStringM constructor validates length).

Updates CHANGELOG.md (Unreleased > Bug Fixes).