### PR TITLE
Add distance_to_next for adjacent event distances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 **Improvements:**
 
+* Added `DataFrame.lr.distance_to_next()` accessor method (and the underlying `EventsData.distance_to_next()`) for computing the linear distance between each event and its adjacent event within the same group, e.g., the gap between consecutive events along a reference line. Supports configurable measurement anchors (`anchor`, defaulting to the end-to-begin gap for linear events and location-to-location for point events), forward/backward attribution (`direction`), negative-distance handling for overlaps (`negatives={'keep','zero','absolute','raise'}`), and standard-order sorting with realignment to the original event order (`sort`). The accessor returns a `pd.Series` aligned to the DataFrame index.
 * Added `linref.__version__` attribute, resolved at import time from the installed package metadata via `importlib.metadata.version()`. Falls back to `"unknown"` when the package metadata cannot be found.
 * Added `DataFrame.lr.parallel_project_hausdorff()` accessor method, exposing the existing `linref.ext.spatial.parallel_project_hausdorff()` function through the `.lr` accessor. The active DataFrame serves as the projection target. Also updated documentation example 04 to reflect this simplified pattern.
 

--- a/linref/events/base.py
+++ b/linref/events/base.py
@@ -937,6 +937,119 @@ class EventsData:
         res[1:] = np.cumsum(~self.next_consecutive(all_=False))
         return res
 
+    def distance_to_next(
+            self,
+            anchor: str | tuple[str, str] | None = None,
+            direction: str = 'forward',
+            negatives: str = 'keep',
+            sort: bool = True
+        ) -> np.ndarray:
+        """
+        Compute the linear distance between each event and its adjacent event
+        within the same group, e.g., the gap between consecutive events along
+        a reference line.
+
+        Parameters
+        ----------
+        anchor : str or tuple of str, optional
+            The event anchor point(s) used to measure distance. A single anchor
+            name is applied to both events; a tuple ``(from_anchor, to_anchor)``
+            measures from ``from_anchor`` on the earlier event to ``to_anchor``
+            on the later event. Valid anchors are {'begs', 'ends', 'centers', 
+            'locs'}, subject to event type. If None, defaults to 
+            ('ends', 'begs') for linear events (the gap between consecutive 
+            events) and ('locs', 'locs') for point events.
+        direction : {'forward', 'backward'}, default 'forward'
+            Whether each distance is attributed to the earlier event (forward,
+            the distance to the next event, with the last event in each group
+            set to NaN) or the later event (backward, the distance from the
+            previous event, with the first event in each group set to NaN).
+        negatives : {'keep', 'zero', 'absolute', 'raise'}, default 'keep'
+            How to treat negative distances, which arise from overlapping or
+            out-of-order events. 'keep' returns signed values, 'zero' clamps
+            negatives to zero, 'absolute' returns magnitudes, and 'raise'
+            raises an error if any negative distance is encountered.
+        sort : bool, default True
+            Whether to sort the events by their standard order before computing
+            distances, realigning the results to the original event order. If
+            False, distances are computed on the current event order.
+
+        Returns
+        -------
+        np.ndarray
+            An array of distances aligned to the events, with NaN where no
+            adjacent event exists within the group.
+        """
+        # Validate parameters
+        if direction not in common.distance_directions:
+            raise ValueError(
+                f"Invalid direction '{direction}'. Must be one of "
+                f"{sorted(common.distance_directions)}.")
+        if negatives not in common.distance_negatives:
+            raise ValueError(
+                f"Invalid negatives '{negatives}'. Must be one of "
+                f"{sorted(common.distance_negatives)}.")
+        
+        # Resolve and validate anchors, defaulting to the gap between events
+        if anchor is None:
+            anchor = ('locs', 'locs') if self.is_point else ('ends', 'begs')
+        elif isinstance(anchor, str):
+            anchor = (anchor, anchor)
+        try:
+            from_anchor, to_anchor = anchor
+        except ValueError:
+            raise ValueError(
+                f"Invalid anchor format '{anchor}'. Must be a string or a tuple of two strings.")
+        valid = set(self.anchors) | {'centers'} # centers is derivable for all
+        for a in (from_anchor, to_anchor):
+            if a not in valid:
+                raise ValueError(
+                    f"Invalid anchor '{a}' for these events. Must be one of "
+                    f"{sorted(valid)}.")
+
+        # Optionally sort by standard order, computing on the sorted order
+        n = self.num_events
+        if sort:
+            target, sorter = self.sort_standard(return_index=True)
+        else:
+            target = self
+
+        # Compute distances between consecutive event pairs. For n < 2, the
+        # slices are empty, yielding an empty pair array and an all-NaN result.
+        from_arr = getattr(target, from_anchor)
+        to_arr = getattr(target, to_anchor)
+        pair_dist = np.asarray(to_arr[1:] - from_arr[:-1], dtype=float)
+        # Mask pairs that cross group boundaries
+        if target.is_grouped:
+            same_group = target.groups[1:] == target.groups[:-1]
+            pair_dist[~same_group] = np.nan
+
+        # Attribute distances to rows based on direction
+        result = np.full(n, np.nan, dtype=float)
+        if direction == 'forward':
+            result[:-1] = pair_dist
+        else:
+            result[1:] = pair_dist
+
+        # Realign to the original event order if sorted
+        if sort:
+            inverse = np.empty_like(sorter)
+            inverse[sorter] = np.arange(n)
+            result = result[inverse]
+
+        # Handle negative values from overlapping or out-of-order events
+        if negatives == 'zero':
+            result[result < 0] = 0.0
+        elif negatives == 'absolute':
+            result = np.abs(result)
+        elif negatives == 'raise':
+            if np.any(result < 0):
+                raise ValueError(
+                    "Negative distances encountered due to overlapping or "
+                    "out-of-order events. Set `negatives` to 'keep', 'zero', "
+                    "or 'absolute' to handle these values.")
+        return result
+
     @utility._method_require(is_grouped=True)
     def iter_groups(self, ungroup: bool = True) -> Iterator[tuple]:
         """

--- a/linref/events/common.py
+++ b/linref/events/common.py
@@ -9,3 +9,5 @@ anchors_locs = {'begs', 'ends', 'centers'}
 closed_all = {'left', 'left_mod', 'right', 'right_mod', 'both', 'neither'}
 closed_base = {'left', 'right', 'both', 'neither'}
 segment_fill_all = {'none','cut','left','right','extend','balance'}
+distance_directions = {'forward', 'backward'}
+distance_negatives = {'keep', 'zero', 'absolute', 'raise'}

--- a/linref/ext/base.py
+++ b/linref/ext/base.py
@@ -1059,6 +1059,58 @@ class LRS_Accessor(object):
         groups, counts = self.events.group_counts()
         return pd.Series(data=counts, index=groups)
 
+    def distance_to_next(
+        self,
+        anchor: str | tuple[str, str] | None = None,
+        direction: str = 'forward',
+        negatives: str = 'keep',
+        sort: bool = True
+    ) -> pd.Series:
+        """
+        Compute the linear distance between each event and its adjacent event
+        within the same group based on the LRS key columns, e.g., the gap
+        between consecutive events along a reference line.
+
+        Parameters
+        ----------
+        anchor : str or tuple of str, optional
+            The event anchor point(s) used to measure distance. A single anchor
+            name is applied to both events; a tuple ``(from_anchor, to_anchor)``
+            measures from ``from_anchor`` on the earlier event to ``to_anchor``
+            on the later event. Valid anchors are {'begs', 'ends', 'centers', 
+            'locs'}, subject to event type. If None, defaults to 
+            ('ends', 'begs') for linear events (the gap between consecutive 
+            events) and ('locs', 'locs') for point events.
+        direction : {'forward', 'backward'}, default 'forward'
+            Whether each distance is attributed to the earlier event (forward,
+            the distance to the next event, with the last event in each group
+            set to NaN) or the later event (backward, the distance from the
+            previous event, with the first event in each group set to NaN).
+        negatives : {'keep', 'zero', 'absolute', 'raise'}, default 'keep'
+            How to treat negative distances, which arise from overlapping or
+            out-of-order events. 'keep' returns signed values, 'zero' clamps
+            negatives to zero, 'absolute' returns magnitudes, and 'raise'
+            raises an error if any negative distance is encountered.
+        sort : bool, default True
+            Whether to sort the events by their standard order before computing
+            distances, realigning the results to the original DataFrame order.
+            If False, distances are computed on the current DataFrame order.
+
+        Returns
+        -------
+        distances : pd.Series
+            A series of distances aligned to the DataFrame, with NaN where no
+            adjacent event exists within the group.
+        """
+        distances = self.events.distance_to_next(
+            anchor=anchor,
+            direction=direction,
+            negatives=negatives,
+            sort=sort
+        )
+        return pd.Series(
+            data=distances, index=self.index, name='distance_to_next')
+
     def sort_standard(
         self,
         return_index: bool = False,

--- a/linref/tests/test_ext_base.py
+++ b/linref/tests/test_ext_base.py
@@ -669,6 +669,68 @@ class TestEventOperations(unittest.TestCase):
         self.assertTrue(result.lr.lrs == df_eclipsed.lr.lrs)
 
 
+class TestDistanceToNext(unittest.TestCase):
+    """Test the distance_to_next method."""
+
+    def setUp(self):
+        """Set up linear and point test DataFrames."""
+        # Linear events with a gap in group A and an overlap in group A
+        self.df_linear = pd.DataFrame({
+            'route': ['A', 'A', 'A', 'B', 'B'],
+            'beg': [0.0, 6.0, 9.0, 0.0, 5.0],
+            'end': [5.0, 10.0, 12.0, 4.0, 8.0],
+        }).lr.set_lrs(key_col='route', beg_col='beg', end_col='end', closed='right')
+        # Point events
+        self.df_point = pd.DataFrame({
+            'route': ['A', 'A', 'A', 'B'],
+            'loc': [0.0, 3.0, 10.0, 2.0],
+        }).lr.set_lrs(key_col='route', loc_col='loc')
+
+    def test_default_linear_gap(self):
+        """Default anchor measures the ends->begs gap, last-in-group is NaN."""
+        result = self.df_linear.lr.distance_to_next()
+        self.assertIsInstance(result, pd.Series)
+        np.testing.assert_array_equal(
+            result.values, [1.0, -1.0, np.nan, 1.0, np.nan])
+
+    def test_default_point_locs(self):
+        """Point events default to locs->locs distance."""
+        result = self.df_point.lr.distance_to_next()
+        np.testing.assert_array_equal(result.values, [3.0, 7.0, np.nan, np.nan])
+
+    def test_direction_backward(self):
+        """Backward attributes the gap to the later event, first-in-group NaN."""
+        result = self.df_linear.lr.distance_to_next(direction='backward')
+        np.testing.assert_array_equal(
+            result.values, [np.nan, 1.0, -1.0, np.nan, 1.0])
+
+    def test_negatives_zero(self):
+        """Overlaps (negative distances) are clamped to zero."""
+        result = self.df_linear.lr.distance_to_next(negatives='zero')
+        np.testing.assert_array_equal(
+            result.values, [1.0, 0.0, np.nan, 1.0, np.nan])
+
+    def test_negatives_raise(self):
+        """Negative distances raise when negatives='raise'."""
+        with self.assertRaises(ValueError):
+            self.df_linear.lr.distance_to_next(negatives='raise')
+
+    def test_anchor_tuple(self):
+        """A single anchor string applies to both events."""
+        result = self.df_linear.lr.distance_to_next(anchor='begs')
+        np.testing.assert_array_equal(
+            result.values, [6.0, 3.0, np.nan, 5.0, np.nan])
+
+    def test_sort_realignment(self):
+        """Unsorted input with sort=True realigns to original DataFrame order."""
+        shuffled = self.df_linear.iloc[[2, 0, 4, 1, 3]]
+        result = shuffled.lr.distance_to_next()
+        # Values align to original rows regardless of input order
+        expected = pd.Series(
+            [np.nan, 1.0, np.nan, -1.0, 1.0], index=[2, 0, 4, 1, 3])
+        np.testing.assert_array_equal(result.values, expected.values)
+
+
 class TestCompatibilityFunctions(unittest.TestCase):
     """Test compatibility checking functions."""
 


### PR DESCRIPTION
## Summary

Adds `DataFrame.lr.distance_to_next()` (and the underlying `EventsData.distance_to_next()`) for computing the linear distance between each event and its adjacent event within the same group — e.g., the gap between consecutive events along a reference line.

## Features

- Configurable measurement anchors via `anchor` (defaults to the end-to-begin gap for linear events and location-to-location for point events).
- Forward/backward attribution via `direction`.
- Negative-distance handling for overlaps via `negatives={'keep','zero','absolute','raise'}`.
- Standard-order sorting with realignment to the original event order via `sort`.
- Returns a `pd.Series` aligned to the DataFrame index.

## Tests

Covered by `TestDistanceToNext` in `test_ext_base.py` (default linear gap, point locations, backward direction, negatives handling, anchor tuple, and sort realignment).