### PR TITLE
Add match_groups parameter to intersection generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
 
 * Fixed internal method decorators to preserve wrapped function metadata via `functools.wraps`, so decorated methods now render with proper signatures and docstrings in the API documentation.
 * Fixed `LineStringM.cut()` to pin the terminal M values of the cut geometry to the exact requested begin/end measures instead of re-interpolating them. Re-interpolation could introduce sub-ULP drift between adjacent segments' shared borders during the dissolve → resegment workflow, causing `DataFrame.lr.dissolve()` to incorrectly report contiguous geometries as disjointed. Also removed a now-unreachable M/coordinate length-reconciliation branch, since `substring_m_coords()` always returns equal-length arrays.
+* `DataFrame.lr.dissolve()` now validates that its key columns (LRS key columns and any `retain` columns) contain no null values, raising a clear `ValueError` naming the offending column(s) instead of failing later with an opaque sort `TypeError`.
+* Fixed the `mode` aggregator to return `np.nan` instead of `None` for empty values in its object/string branch, matching the null representation used by the other aggregators (`mean`, `single`, `first`, `last`).
+* Improved handling of null-group events in relation operations: events with null group keys are now excluded from grouped relate operations (producing empty rows/columns), null masks are computed robustly for both plain and structured/record key arrays, and mixed-type group keys now raise a clear `TypeError` at the sort boundary.
 
 ## 1.0.0 (2026-07-10) - Major Architectural Overhaul
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 * Added `linref.__version__` attribute, resolved at import time from the installed package metadata via `importlib.metadata.version()`. Falls back to `"unknown"` when the package metadata cannot be found.
 * Added `DataFrame.lr.parallel_project_hausdorff()` accessor method, exposing the existing `linref.ext.spatial.parallel_project_hausdorff()` function through the `.lr` accessor. The active DataFrame serves as the projection target. Also updated documentation example 04 to reflect this simplified pattern.
+* Added an optional `match_groups` parameter to `DataFrame.lr.generate_intersections()`, `generate_intersection_pairs()`, and `generate_intersection_nodes()`. When specified, an intersection is only created between two geometries when they share the same value across all named columns, e.g. a road level or layer field (such as OSM `layer`) so that roads on different levels do not create intersection points. The specified columns must not contain null values; a clear `ValueError` is raised otherwise.
 
 **Bug Fixes:**
 

--- a/linref/ext/base.py
+++ b/linref/ext/base.py
@@ -1904,6 +1904,15 @@ class LRS_Accessor(object):
                     f"remove_key()."
                 )
             key_col = retain
+        # Enforce non-null key columns (LRS keys and retained columns); null
+        # values make groups incomparable when sorting during dissolve.
+        null_cols = [c for c in key_col if self.df[c].isna().any()]
+        if null_cols:
+            raise ValueError(
+                f"Key columns {null_cols} contain null values, which cannot be "
+                f"used to group and sort events during dissolve. Please resolve "
+                f"missing values before dissolving."
+            )
         # Dissolve events
         events = self.get_events(key_col=key_col, require=True)
         data, index, relation = events.dissolve(sort=sort, return_index=True, return_relation=True)

--- a/linref/ext/base.py
+++ b/linref/ext/base.py
@@ -2982,6 +2982,7 @@ class LRS_Accessor(object):
     def generate_intersections(
         self,
         exclude_groups: bool | str | list[str] = True,
+        match_groups: str | list[str] | None = None,
         touches: bool = True,
         crosses: bool = True,
         project: bool = True,
@@ -3004,6 +3005,16 @@ class LRS_Accessor(object):
               intersections between segments of the same route.
             - str or list of str : Use the specified column name(s).
             - False : No group exclusion; all intersecting pairs are included.
+        match_groups : str or list of str, optional
+            Column name(s) that must match for an intersection to be created.
+            Pairs are kept only when both geometries share the same value
+            across all of these columns. Useful for fields that indicate
+            whether two geometries are physically connected, such as a road
+            level or layer field (e.g. OSM ``layer``): roads on different
+            levels do not create intersection points, while roads on the same
+            level do. The specified columns must not contain null values;
+            missing values are ambiguous for matching and must be resolved
+            before calling this method.
         touches : bool, default True
             If True, include pairs that share boundary points (endpoints) only.
         crosses : bool, default True
@@ -3047,7 +3058,8 @@ class LRS_Accessor(object):
             cols = exclude_groups
         # Generate intersection nodes (tuple of arrays)
         geoms, indices = generate_intersection_nodes(
-            self.df, exclude_groups=cols, touches=touches, crosses=crosses
+            self.df, exclude_groups=cols, match_groups=match_groups,
+            touches=touches, crosses=crosses,
         )
         # Construct GeoDataFrame from arrays
         result = gpd.GeoDataFrame(

--- a/linref/ext/spatial.py
+++ b/linref/ext/spatial.py
@@ -562,6 +562,7 @@ class ParallelProjector(object):
 def generate_intersection_pairs(
     gdf: gpd.GeoDataFrame,
     exclude_groups: str | list[str] | None = None,
+    match_groups: str | list[str] | None = None,
     touches: bool = True,
     crosses: bool = True,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -579,6 +580,11 @@ def generate_intersection_pairs(
         Column name(s) used for group exclusion. Pairs where both geometries
         share the same value in these columns are excluded from results. 
         Useful for excluding intersections between segments of the same route.
+    match_groups : str or list of str, optional
+        Column name(s) that must match for an intersection to be created. 
+        Pairs are kept only when both geometries share the same value across 
+        all of these columns, such as a road level or layer. The specified 
+        columns must not contain null values.
     touches : bool, default True
         If True, include pairs that share boundary points (endpoints) only.
     crosses : bool, default True
@@ -598,7 +604,9 @@ def generate_intersection_pairs(
     Raises
     ------
     ValueError
-        If both `touches` and `crosses` are False.
+        If both `touches` and `crosses` are False, if columns specified in
+        `exclude_groups` or `match_groups` are not found in the GeoDataFrame,
+        or if any `match_groups` column contains null values.
     """
     # Validate inputs
     if not isinstance(gdf, gpd.GeoDataFrame):
@@ -614,6 +622,23 @@ def generate_intersection_pairs(
             raise ValueError(
                 f"Columns {missing} specified in exclude_groups are not "
                 f"found in the GeoDataFrame."
+            )
+
+    # Normalize match_groups to list or None
+    match_groups = label_list_or_none(match_groups)
+    if match_groups is not None:
+        missing = [c for c in match_groups if c not in gdf.columns]
+        if missing:
+            raise ValueError(
+                f"Columns {missing} specified in match_groups are not "
+                f"found in the GeoDataFrame."
+            )
+        null_cols = [c for c in match_groups if gdf[c].isna().any()]
+        if null_cols:
+            raise ValueError(
+                f"Columns {null_cols} specified in match_groups contain null "
+                f"values. Null values are ambiguous for matching and must be "
+                f"resolved before calling this function."
             )
 
     # Extract geometry array and index
@@ -663,6 +688,21 @@ def generate_intersection_pairs(
     if len(left_idx) == 0:
         return empty
 
+    # Keep only pairs that match across all required columns
+    if match_groups is not None:
+        match_values = gdf[match_groups].values
+        left_match = match_values[left_idx]
+        right_match = match_values[right_idx]
+        if left_match.ndim == 1:
+            same_match = left_match == right_match
+        else:
+            same_match = np.all(left_match == right_match, axis=1)
+        left_idx = left_idx[same_match]
+        right_idx = right_idx[same_match]
+
+    if len(left_idx) == 0:
+        return empty
+
     # Compute intersection geometries
     intersections = shapely.intersection(geoms[left_idx], geoms[right_idx])
     index_left = idx[left_idx]
@@ -673,6 +713,7 @@ def generate_intersection_pairs(
 def generate_intersection_nodes(
     gdf: gpd.GeoDataFrame,
     exclude_groups: str | list[str] | None = None,
+    match_groups: str | list[str] | None = None,
     touches: bool = True,
     crosses: bool = True,
 ) -> tuple[np.ndarray, list[list]]:
@@ -692,6 +733,15 @@ def generate_intersection_nodes(
         Column name(s) used for group exclusion. Pairs where both geometries
         share the same value in these columns are excluded from results.
         Useful for excluding intersections between segments of the same route.
+    match_groups : str or list of str, optional
+        Column name(s) that must match for an intersection to be created.
+        Pairs are kept only when both geometries share the same value across
+        all of these columns. Useful for fields that indicate whether two
+        geometries are physically connected, such as a road level or layer
+        field (e.g. OSM ``layer``): roads on different levels do not create
+        intersection points, while roads on the same level do. The specified
+        columns must not contain null values; missing values are ambiguous
+        for matching and must be resolved before calling this function.
     touches : bool, default True
         If True, include pairs that share boundary points (endpoints) only.
     crosses : bool, default True
@@ -708,7 +758,8 @@ def generate_intersection_nodes(
     """
     # Get pairwise intersection arrays
     intersections, index_left, index_right = generate_intersection_pairs(
-        gdf, exclude_groups=exclude_groups, touches=touches, crosses=crosses
+        gdf, exclude_groups=exclude_groups, match_groups=match_groups,
+        touches=touches, crosses=crosses,
     )
 
     # Empty result

--- a/linref/tests/test_ext_base.py
+++ b/linref/tests/test_ext_base.py
@@ -615,6 +615,22 @@ class TestEventOperations(unittest.TestCase):
             LineString([(0, 0), (1, 0), (2, 0)])
         ))
 
+    def test_dissolve_null_retain_column_raises(self):
+        """Dissolving with a null-containing retain column raises ValueError."""
+        df = self.df.copy()
+        df.loc[0, 'attr'] = None
+        with self.assertRaises(ValueError) as ctx:
+            df.lr.dissolve(retain=['attr'])
+        self.assertIn('attr', str(ctx.exception))
+
+    def test_dissolve_null_key_column_raises(self):
+        """Dissolving with a null-containing LRS key column raises ValueError."""
+        df = self.df.copy()
+        df.loc[0, 'route'] = None
+        with self.assertRaises(ValueError) as ctx:
+            df.lr.dissolve(retain=['attr'])
+        self.assertIn('route', str(ctx.exception))
+
     def test_resegment(self):
         """Test resegmenting events."""
         df_resegmented = self.df.lr.resegment(length=0.5, fill='cut', cut_geom=False)

--- a/linref/tests/test_ext_spatial.py
+++ b/linref/tests/test_ext_spatial.py
@@ -104,6 +104,52 @@ class TestGenerateIntersectionPairs(unittest.TestCase):
         with self.assertRaises(ValueError):
             generate_intersection_pairs(self.gdf, exclude_groups='bad_col')
 
+    def test_match_groups(self):
+        """match_groups keeps only pairs sharing the same value."""
+        gdf = self.gdf.copy()
+        # A1 and B1 cross at (5,0) but on different levels; A2 and B2 match
+        gdf['level'] = [0, 0, 1, 0]
+        intersections, index_left, index_right = generate_intersection_pairs(
+            gdf, match_groups='level'
+        )
+        # A1×A2 (both 0, touch), A2×B2 (both 0, cross) kept; A1×B1 dropped
+        self.assertEqual(len(intersections), 2)
+        self.assertEqual(list(intersections), [Point(10, 0), Point(15, 0)])
+
+    def test_match_groups_multiple_columns(self):
+        """match_groups with multiple columns requires all to match."""
+        gdf = self.gdf.copy()
+        gdf['level'] = [0, 0, 0, 0]
+        gdf['deck'] = ['x', 'x', 'y', 'x']
+        intersections, _, _ = generate_intersection_pairs(
+            gdf, match_groups=['level', 'deck']
+        )
+        # A1×B1 dropped (deck differs); A1×A2 and A2×B2 kept
+        self.assertEqual(len(intersections), 2)
+
+    def test_match_groups_with_exclude_groups(self):
+        """match_groups and exclude_groups compose together."""
+        gdf = self.gdf.copy()
+        gdf['level'] = [0, 0, 1, 0]
+        intersections, _, _ = generate_intersection_pairs(
+            gdf, exclude_groups='route_id', match_groups='level'
+        )
+        # A1×A2 excluded (same route); A1×B1 dropped (level); A2×B2 kept
+        self.assertEqual(len(intersections), 1)
+        self.assertEqual(list(intersections), [Point(15, 0)])
+
+    def test_match_groups_missing_column_raises(self):
+        """Nonexistent match_groups column raises ValueError."""
+        with self.assertRaises(ValueError):
+            generate_intersection_pairs(self.gdf, match_groups='bad_col')
+
+    def test_match_groups_null_values_raise(self):
+        """Null values in match_groups columns raise ValueError."""
+        gdf = self.gdf.copy()
+        gdf['level'] = [0, None, 1, 0]
+        with self.assertRaises(ValueError):
+            generate_intersection_pairs(gdf, match_groups='level')
+
     def test_invalid_input_raises(self):
         """Non-GeoDataFrame input raises TypeError."""
         with self.assertRaises(TypeError):


### PR DESCRIPTION
## Summary

Adds an optional `match_groups` parameter to the intersection generation functions so that intersections are only created between geometries that share the same value across one or more named columns.

The motivating use case is fields that indicate whether two roads are physically connected — for example a road level / layer field (such as OSM `layer`). Roads on different levels (e.g. a bridge crossing a road below) should not create intersection points, while roads on the same level should.

This is the complement of the existing `exclude_groups` parameter (which drops pairs that *share* a value); the two compose together.

## Changes

- `generate_intersection_pairs()` and `generate_intersection_nodes()` in `linref/ext/spatial.py` gain a `match_groups` parameter.
- `DataFrame.lr.generate_intersections()` in `linref/ext/base.py` exposes the parameter through the accessor.
- Null values in `match_groups` columns raise a clear `ValueError` — matching against nulls is ambiguous and must be resolved by the caller before invoking these functions.
- Added tests covering single/multiple match columns, composition with `exclude_groups`, missing-column errors, and null-value errors.
- Changelog note added under Unreleased.

## Testing

`python -m pytest linref/tests/test_ext_spatial.py` — 34 passed.
