### PR TITLE
Fix lr.clip misclassifying segments at the mask boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,18 @@ All notable changes to this project will be documented in this file.
 
 **Bug Fixes:**
 
+* Fixed `DataFrame.lr.clip()` to decide membership by geometric overlay against the mask (`intersection` for `keep='inside'`, `difference` for `keep='outside'`) instead of filtering split segments with an exact spatial predicate. Splitting places segment endpoints on the mask boundary, where floating point cannot represent them exactly, so `covered_by` rejected segments which were geometrically inside the mask: `keep='inside'` dropped them and `keep='outside'` returned every segment. Clipped geometries are now the overlay geometries themselves, so the two results tile the input events exactly.
+* Fixed `DataFrame.lr.clip()` raising a `KeyError` when called with `cut_geom=False`, since the predicate filter required the geometry column which the underlying `split()` call had already dropped. The result now drops the geometry and M-enabled geometry columns and returns the clipped measures.
+* `DataFrame.lr.clip()` now returns a result which carries the LRS settings of the input DataFrame, so its output can be chained with further `.lr` methods without re-applying the LRS.
 * Fixed internal method decorators to preserve wrapped function metadata via `functools.wraps`, so decorated methods now render with proper signatures and docstrings in the API documentation.
 * Fixed `LineStringM.cut()` to pin the terminal M values of the cut geometry to the exact requested begin/end measures instead of re-interpolating them. Re-interpolation could introduce sub-ULP drift between adjacent segments' shared borders during the dissolve → resegment workflow, causing `DataFrame.lr.dissolve()` to incorrectly report contiguous geometries as disjointed. Also removed a now-unreachable M/coordinate length-reconciliation branch, since `substring_m_coords()` always returns equal-length arrays.
 * `DataFrame.lr.dissolve()` now validates that its key columns (LRS key columns and any `retain` columns) contain no null values, raising a clear `ValueError` naming the offending column(s) instead of failing later with an opaque sort `TypeError`.
 * Fixed the `mode` aggregator to return `np.nan` instead of `None` for empty values in its object/string branch, matching the null representation used by the other aggregators (`mean`, `single`, `first`, `last`).
 * Improved handling of null-group events in relation operations: events with null group keys are now excluded from grouped relate operations (producing empty rows/columns), null masks are computed robustly for both plain and structured/record key arrays, and mixed-type group keys now raise a clear `TypeError` at the sort boundary.
+
+**Deprecations:**
+
+* The `predicate` parameter of `DataFrame.lr.clip()` is deprecated and no longer has any effect. Membership is now determined by geometric overlay against the mask, so no spatial predicate is consulted. Passing the parameter emits a `LinrefDeprecationWarning`.
 
 ## 1.0.0 (2026-07-10) - Major Architectural Overhaul
 

--- a/linref/ext/base.py
+++ b/linref/ext/base.py
@@ -16,7 +16,7 @@ from linref.events.base import EventsData
 from linref.events.utility import _method_require
 from linref.events import modify, relate, integration
 from linref import geometry
-from linref.errors import LRSConfigurationError, LRSCompatibilityError, GeometryTopologyError, GeometryMeasureError
+from linref.errors import LRSConfigurationError, LRSCompatibilityError, GeometryTopologyError, GeometryMeasureError, LinrefDeprecationWarning
 from linref.ext.validation import _method_deprecates_geometry
 from linref.ext.lrs import LRS
 from linref.options import options, set_default_lrs
@@ -2278,13 +2278,15 @@ class LRS_Accessor(object):
         self,
         mask,
         keep: str = 'inside',
-        predicate: str = 'covered_by',
+        predicate: str | None = None,
         cut_geom: bool = True,
     ) -> pd.DataFrame:
         """
-        Clip linearly-referenced events to a polygon boundary. Events are
-        split where the polygon boundary intersects event geometries, then
-        filtered by their spatial relationship to the polygon.
+        Clip linearly-referenced events to a polygon boundary. The portion of
+        each event geometry which falls inside (or outside) the mask is
+        retained, and its begin and end measures are recovered by projecting
+        the endpoints of that portion onto the M-enabled geometry of the
+        source event.
 
         Parameters
         ----------
@@ -2292,27 +2294,57 @@ class LRS_Accessor(object):
             The polygon geometry or collection of polygon geometries to clip
             against. Must be Polygon or MultiPolygon type.
         keep : {'inside', 'outside'}, default 'inside'
-            Which split segments to retain:
-            - 'inside' : Keep segments that satisfy the predicate against the
-              mask geometry.
-            - 'outside' : Keep segments that do not satisfy the predicate.
-        predicate : str, default 'covered_by'
-            The spatial predicate used to classify segments as "inside" the
-            mask. Common choices:
-            - 'covered_by' : Segment is inside or on the boundary of the mask.
-            - 'within' : Segment is strictly inside the mask (boundary-
-              coincident segments are excluded).
+            Which clipped portions to retain:
+            - 'inside' : Keep the portions of events covered by the mask.
+            - 'outside' : Keep the portions of events not covered by the mask.
+        predicate : str, optional
+            Deprecated since version 1.1.0 and ignored. Membership is decided
+            by geometric overlay and no spatial predicate is consulted.
         cut_geom : bool, default True
-            Whether to cut new geometries for the split events from the
-            original M-enabled geometries. When True, the result is a
-            GeoDataFrame with valid geometries for each segment.
+            Whether to retain clipped geometries in the result. When True, the
+            result is a GeoDataFrame whose geometries are the clipped
+            geometries themselves, with M-enabled geometries rebuilt to match.
+            When False, the geometry and M-enabled geometry columns are
+            dropped and only the clipped measures are returned.
 
         Returns
         -------
         df : DataFrame or GeoDataFrame
-            A new DataFrame with events clipped to the mask boundary. Returns
-            a GeoDataFrame if ``cut_geom`` is True.
+            A new DataFrame with events clipped to the mask boundary, in
+            standard sort order. Returns a GeoDataFrame if ``cut_geom`` is
+            True.
+
+        Notes
+        -----
+        Membership is decided by geometric overlay, using ``intersection``
+        for ``'inside'`` and ``difference`` for ``'outside'``, rather than by
+        a spatial predicate applied to split segments. Clipping produces
+        endpoints which lie on the mask boundary by construction, and those
+        positions are generally not representable in floating point, so an
+        exact predicate such as ``covered_by`` rejects segments which are
+        geometrically inside the mask. Overlay is self-consistent, so the
+        ``'inside'`` and ``'outside'`` results always tile the input events
+        exactly.
+
+        Events are clipped wherever the mask boundary crosses them, and are
+        also divided at points where the mask boundary grazes them without
+        crossing. A tangency point therefore yields two abutting output events
+        rather than one, matching the behavior of :meth:`split`.
         """
+        # Warn on use of the deprecated predicate parameter. The stacklevel
+        # accounts for the `_method_require` wrapper so the warning is
+        # attributed to the caller.
+        if predicate is not None:
+            warnings.warn(
+                "The `predicate` parameter of `clip` is deprecated since "
+                "linref 1.1.0 and no longer has any effect. Membership is now "
+                "determined by geometric overlay against the mask, which is "
+                "exact at the mask boundary, and no spatial predicate is "
+                "consulted.",
+                LinrefDeprecationWarning,
+                stacklevel=3,
+            )
+
         # Validate keep parameter
         if keep not in ('inside', 'outside'):
             raise ValueError(
@@ -2342,30 +2374,55 @@ class LRS_Accessor(object):
                 "geometries. Use `split()` for LineString masks."
             )
 
-        # Split events at polygon boundaries
-        result = self.split(mask, cut_geom=cut_geom)
-
-        # Build the filter polygon
+        # Build the filter polygon and clip event geometries against it
+        geoms = np.asarray(self.df[self.geom_col].values)
         filter_geom = shapely.union_all(mask_geom)
+        op = shapely.intersection if keep == 'inside' else shapely.difference
+        clipped = op(geoms, filter_geom)
 
-        # Filter by spatial predicate on event geometries
-        geom_col = self.geom_col
-        geom_series = gpd.GeoSeries(
-            result[geom_col].values,
-            crs=getattr(self.df, 'crs', None),
-        )
-        try:
-            mask_test = getattr(geom_series, predicate)(filter_geom)
-        except AttributeError:
-            raise ValueError(
-                f"Invalid value for `predicate`: '{predicate}'. "
-                "Must be a valid spatial predicate method of GeoSeries."
+        # Flatten clipped geometries to their component parts, tracking the
+        # source event each part was clipped from. Overlay returns a Point
+        # where the mask boundary grazes an event without crossing it, and an
+        # empty LineString where nothing of an event is retained; neither is a
+        # valid output event.
+        parts, source_index = shapely.get_parts(clipped, return_index=True)
+        retain = (shapely.get_type_id(parts) == 1) & ~shapely.is_empty(parts)
+        parts, source_index = parts[retain], source_index[retain]
+
+        # Assemble the clipped events, retaining source event attributes
+        result = self.df.iloc[source_index].copy().reset_index(drop=True)
+        if not cut_geom:
+            result = result.drop(
+                columns=[self.geom_col, self.geom_m_col], errors='ignore'
             )
-        if keep == 'outside':
-            mask_test = ~mask_test
-        result = result[mask_test].reset_index(drop=True)
+        result = result.lr.lrs_like(self)
+        if len(result) == 0:
+            return result
 
-        return result
+        # Recover measures by projecting the endpoints of each clipped part
+        # onto the M-enabled geometry of its source event
+        geoms_m = np.asarray(self.geoms_m)[source_index]
+        m_beg = geometry.line_locate_point_m(
+            geoms_m, shapely.get_point(parts, 0), m=True
+        )
+        m_end = geometry.line_locate_point_m(
+            geoms_m, shapely.get_point(parts, -1), m=True
+        )
+        result[self.beg_col] = np.minimum(m_beg, m_end)
+        result[self.end_col] = np.maximum(m_beg, m_end)
+
+        # Apply clipped geometries, rebuilding the inherited M-enabled
+        # geometries which still describe the full source events
+        if cut_geom:
+            result[self.geom_col] = gpd.GeoSeries(
+                parts, crs=getattr(self.df, 'crs', None)
+            )
+            if self.geom_m_col in result.columns:
+                result[self.geom_m_col] = result.lr.build_geom_m()
+
+        # Overlay does not guarantee the ordering of parts along their source
+        # event geometries
+        return result.lr.sort_standard().reset_index(drop=True)
 
     @_method_require(is_linear=True)
     def integrate(

--- a/linref/tests/test_ext_base.py
+++ b/linref/tests/test_ext_base.py
@@ -11,6 +11,7 @@ Tests cover:
 
 import unittest
 import os
+import warnings
 import numpy as np
 import pandas as pd
 import geopandas as gpd
@@ -20,7 +21,7 @@ import linref
 from linref import LRS, LRS_Accessor, integrate
 from linref.options import options, set_default_lrs
 from linref.ext.base import check_compatibility
-from linref.errors import LRSConfigurationError, LRSCompatibilityError
+from linref.errors import LRSConfigurationError, LRSCompatibilityError, LinrefDeprecationWarning
 from linref.geometry import LineStringM
 
 
@@ -2391,10 +2392,17 @@ class TestClipMethod(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.roads.lr.clip(self.polygon, keep='middle')
 
-    def test_clip_invalid_predicate(self):
-        """Invalid predicate raises ValueError or AttributeError."""
-        with self.assertRaises((ValueError, AttributeError)):
+    def test_clip_predicate_deprecated(self):
+        """The predicate parameter warns and is otherwise ignored."""
+        # An invalid predicate no longer raises; it is never consulted
+        with self.assertWarns(LinrefDeprecationWarning):
             self.roads.lr.clip(self.polygon, predicate='not_a_predicate')
+
+    def test_clip_no_predicate_does_not_warn(self):
+        """Omitting the predicate parameter raises no deprecation warning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', LinrefDeprecationWarning)
+            self.roads.lr.clip(self.polygon)
 
     def test_clip_non_polygon_mask(self):
         """Non-polygon mask raises TypeError."""
@@ -2412,6 +2420,220 @@ class TestClipMethod(unittest.TestCase):
             (outside['end'] - outside['beg']).sum()
         )
         self.assertAlmostEqual(orig_miles, clip_miles, places=6)
+
+    def test_clip_cuts_geometry(self):
+        """Clipped geometries match their clipped measures."""
+        result = self.roads.lr.clip(self.polygon)
+
+        self.assertIsInstance(result, gpd.GeoDataFrame)
+        for _, row in result.iterrows():
+            self.assertAlmostEqual(
+                row['geometry'].length, row['end'] - row['beg'], places=6
+            )
+            # M-enabled geometries are rebuilt for the clipped part rather
+            # than inherited from the source event
+            self.assertTrue(row['geometry_m'].geom.equals(row['geometry']))
+            self.assertAlmostEqual(row['geometry_m'].beg_m, row['beg'], places=6)
+            self.assertAlmostEqual(row['geometry_m'].end_m, row['end'], places=6)
+
+    def test_clip_no_cut_geom(self):
+        """Clip with cut_geom=False drops the geometry columns."""
+        result = self.roads.lr.clip(self.polygon, cut_geom=False)
+
+        self.assertNotIn('geometry', result.columns)
+        self.assertNotIn('geometry_m', result.columns)
+        np.testing.assert_array_almost_equal(result['beg'].values, [3, 5, 10])
+        np.testing.assert_array_almost_equal(result['end'].values, [5, 10, 12])
+
+    def test_clip_retains_attributes_and_lrs(self):
+        """Clip retains source attributes and LRS settings."""
+        result = self.roads.lr.clip(self.polygon)
+
+        self.assertTrue(result.lr.lrs == self.roads.lr.lrs)
+        self.assertEqual(result['attr'].tolist(), ['x', 'y', 'z'])
+        self.assertEqual(result['route'].tolist(), ['A', 'A', 'A'])
+
+    def test_clip_no_intersection(self):
+        """A mask which misses all events keeps nothing inside, all outside."""
+        from shapely.geometry import Polygon
+        far_poly = Polygon([(100, 100), (200, 100), (200, 200), (100, 200)])
+
+        inside = self.roads.lr.clip(far_poly, keep='inside')
+        self.assertEqual(len(inside), 0)
+        self.assertTrue(inside.lr.lrs == self.roads.lr.lrs)
+
+        outside = self.roads.lr.clip(far_poly, keep='outside')
+        np.testing.assert_array_almost_equal(outside['beg'].values, [0, 5, 10])
+        np.testing.assert_array_almost_equal(outside['end'].values, [5, 10, 15])
+
+    def test_clip_multiple_routes(self):
+        """Clip orders its output by group, as `split` does."""
+        from shapely.geometry import Polygon
+
+        roads = gpd.GeoDataFrame({
+            'route': ['B', 'A'],
+            'beg': [0.0, 0.0],
+            'end': [10.0, 10.0],
+            'geometry': [
+                LineString([(0, 5), (10, 5)]),
+                LineString([(0, 0), (10, 0)]),
+            ],
+        }, geometry='geometry')
+        roads['geometry_m'] = [
+            LineStringM(geom, m=[0.0, 10.0]) for geom in roads.geometry
+        ]
+        roads = roads.lr.set_lrs(
+            key_col=['route'],
+            loc_col='milepost',
+            beg_col='beg',
+            end_col='end',
+            geom_col='geometry',
+            geom_m_col='geometry_m',
+            closed='left_mod',
+        )
+        result = roads.lr.clip(Polygon([(2, -1), (8, -1), (8, 6), (2, 6)]))
+
+        self.assertEqual(result['route'].tolist(), ['A', 'B'])
+        np.testing.assert_array_almost_equal(result['beg'].values, [2, 2])
+        np.testing.assert_array_almost_equal(result['end'].values, [8, 8])
+
+
+class TestClipBoundaryPrecision(unittest.TestCase):
+    """
+    Test clip against masks whose boundary crossings are not exactly
+    representable in floating point.
+
+    Clipping produces endpoints which lie on the mask boundary by
+    construction. An exact spatial predicate such as ``covered_by`` cannot
+    reliably classify such geometry, so membership must be decided by
+    geometric overlay instead. See issue #42.
+    """
+
+    def setUp(self):
+        """Set up a single chord through a circular mask."""
+        # Coordinates chosen so the boundary crossings are not exactly
+        # representable; the mask comes from buffer(), as any real-world
+        # walkshed, catchment, or corridor mask would
+        self.x, self.y = 2035759.1455780738, 1104936.629180962
+        self.line = LineString([
+            (self.x - 12000, self.y - 3000),
+            (self.x + 9000, self.y + 4000),
+        ])
+        self.mask = Point(self.x, self.y).buffer(2640)
+        self.roads = self._build(self.line)
+
+    def _build(self, line):
+        """Build a single-event GeoDataFrame for the given line."""
+        df = gpd.GeoDataFrame({
+            'route': ['A'],
+            'beg': [0.0],
+            'end': [line.length],
+            'geometry': [line],
+        }, geometry='geometry')
+        df['geometry_m'] = [LineStringM(line, m=[0.0, line.length])]
+        return df.lr.set_lrs(
+            key_col=['route'],
+            loc_col='milepost',
+            beg_col='beg',
+            end_col='end',
+            geom_col='geometry',
+            geom_m_col='geometry_m',
+            closed='left_mod',
+        )
+
+    def test_clip_inside_keeps_the_inside_segment(self):
+        """A chord crossing a circular mask yields one inside segment."""
+        result = self.roads.lr.clip(self.mask, keep='inside')
+
+        self.assertEqual(len(result), 1)
+        # The retained geometry lies entirely within the mask
+        self.assertAlmostEqual(
+            result.geometry.iloc[0].difference(self.mask).length, 0.0, places=6
+        )
+
+    def test_clip_outside_drops_the_inside_segment(self):
+        """A chord crossing a circular mask yields two outside segments."""
+        result = self.roads.lr.clip(self.mask, keep='outside')
+
+        self.assertEqual(len(result), 2)
+        # Neither retained geometry lies within the mask
+        for geom in result.geometry:
+            self.assertAlmostEqual(
+                geom.intersection(self.mask).length, 0.0, places=6
+            )
+
+    def test_clip_tiles_the_source_event(self):
+        """Inside and outside results tile the source event exactly."""
+        inside = self.roads.lr.clip(self.mask, keep='inside')
+        outside = self.roads.lr.clip(self.mask, keep='outside')
+
+        measures = (
+            (inside['end'] - inside['beg']).sum() +
+            (outside['end'] - outside['beg']).sum()
+        )
+        lengths = inside.geometry.length.sum() + outside.geometry.length.sum()
+        self.assertAlmostEqual(measures, self.line.length, places=6)
+        self.assertAlmostEqual(lengths, self.line.length, places=6)
+
+        # The inside segment abuts the outside segments with no gap
+        self.assertEqual(len(inside), 1)
+        self.assertEqual(len(outside), 2)
+        self.assertAlmostEqual(
+            outside['end'].iloc[0], inside['beg'].iloc[0], places=6
+        )
+        self.assertAlmostEqual(
+            outside['beg'].iloc[1], inside['end'].iloc[0], places=6
+        )
+
+    def test_clip_random_chords(self):
+        """Chords through a circular mask clip correctly regardless of angle."""
+        rng = np.random.default_rng(0)
+        radius = 20000
+        tested = 0
+        for _ in range(200):
+            a, b = rng.uniform(0, 2 * np.pi, size=2)
+            line = LineString([
+                (self.x + radius * np.cos(a), self.y + radius * np.sin(a)),
+                (self.x + radius * np.cos(b), self.y + radius * np.sin(b)),
+            ])
+            # Only chords which pass through the mask are of interest
+            if not line.crosses(self.mask.boundary):
+                continue
+            if line.intersection(self.mask).length <= 0:
+                continue
+            tested += 1
+
+            roads = self._build(line)
+            inside = roads.lr.clip(self.mask, keep='inside')
+            outside = roads.lr.clip(self.mask, keep='outside')
+
+            self.assertEqual(len(inside), 1)
+            self.assertEqual(len(outside), 2)
+            self.assertAlmostEqual(
+                inside.geometry.iloc[0].difference(self.mask).length,
+                0.0, places=6,
+            )
+            self.assertAlmostEqual(
+                (inside['end'] - inside['beg']).sum() +
+                (outside['end'] - outside['beg']).sum(),
+                line.length, places=6,
+            )
+        # Guard against the sampling filter silently rejecting every chord
+        self.assertGreater(tested, 10)
+
+    def test_clip_tangent_mask(self):
+        """A mask which grazes an event keeps nothing inside."""
+        line = LineString([(-10, 5), (10, 5)])
+        roads = self._build(line)
+        mask = Point(0, 0).buffer(5)
+
+        self.assertEqual(len(roads.lr.clip(mask, keep='inside')), 0)
+        # The tangency point divides the outside result into two segments
+        outside = roads.lr.clip(mask, keep='outside')
+        self.assertEqual(len(outside), 2)
+        self.assertAlmostEqual(
+            (outside['end'] - outside['beg']).sum(), line.length, places=6
+        )
 
 
 # Run tests


### PR DESCRIPTION
Segments cut at the mask boundary have endpoints floating point cannot represent exactly, so the covered_by filter rejected segments which were geometrically inside. Decide membership by overlay instead, which is exact at the boundary. Also fixes a KeyError under cut_geom=False, carries the input LRS to the result, and deprecates the now-unused predicate parameter.

Addressing #42